### PR TITLE
Escape apostrophes without adding binary font

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -43,28 +43,28 @@ export default function About() {
         {/* Section 01 */}
         <div className="mb-10 md:mb-16">
           <h2 className="text-xl md:text-2xl font-bold mb-3 md:mb-4">
-            <span className="text-gray-400 font-normal">01</span> Where We're At
+            <span className="text-gray-400 font-normal">01</span> Where We’re At
           </h2>
           
           <div className="space-y-3 md:space-y-4 text-sm md:text-base">
             <p>
-              At Wild Studios, we work with brands and creators to design useful tools and experiences. But before thinking about what's next, you've got to understand what's happening right now.
+              At Wild Studios, we work with brands and creators to design useful tools and experiences. But before thinking about what’s next, you’ve got to understand what’s happening right now.
             </p>
             
             <p>
-              We're in a big moment. AI has made it easier and cheaper than ever to build software. Because of that, we think we're about to see tons of new experiments, apps, and genuinely useful tools.
+              We’re in a big moment. AI has made it easier and cheaper than ever to build software. Because of that, we think we’re about to see tons of new experiments, apps, and genuinely useful tools.
             </p>
             
             <p>
-              Things are moving fast. If you build based only on today's assumptions, your product might be old news before you even ship it. AI is changing how software gets made and what users expect from it.
+              Things are moving fast. If you build based only on today’s assumptions, your product might be old news before you even ship it. AI is changing how software gets made and what users expect from it.
             </p>
             
             <p>
-              We think what's coming won't be the same apps recycled again and again. Instead, it'll be highly personalized tools that feel genuinely built for you and the communities you care about.
+              We think what’s coming won’t be the same apps recycled again and again. Instead, it’ll be highly personalized tools that feel genuinely built for you and the communities you care about.
             </p>
             
             <p>
-              We're calling this moment the Imagination Era.
+              We’re calling this moment the Imagination Era.
             </p>
           </div>
         </div>
@@ -77,7 +77,7 @@ export default function About() {
           
           <div className="space-y-3 md:space-y-4 text-sm md:text-base">
             <p>
-              Big changes usually happen when costs drop significantly, and that's exactly what's happening now. Anyone can now build software by simply describing their idea to AI.
+              Big changes usually happen when costs drop significantly, and that’s exactly what’s happening now. Anyone can now build software by simply describing their idea to AI.
             </p>
             
             <p>
@@ -85,7 +85,7 @@ export default function About() {
             </p>
             
             <p>
-              We've seen this happen before. Think about media: once making and sharing videos got cheaper, creators flooded platforms like YouTube and TikTok with content perfectly tailored to niche interests. Suddenly, our feeds felt personal, and media giants had to rethink their approach completely.
+              We’ve seen this happen before. Think about media: once making and sharing videos got cheaper, creators flooded platforms like YouTube and TikTok with content perfectly tailored to niche interests. Suddenly, our feeds felt personal, and media giants had to rethink their approach completely.
             </p>
             
             <p>
@@ -93,7 +93,7 @@ export default function About() {
             </p>
             
             <p>
-              Brands have a clear opportunity here. The chance to build something unique won't stay open forever.
+              Brands have a clear opportunity here. The chance to build something unique won’t stay open forever.
             </p>
           </div>
         </div>
@@ -106,7 +106,7 @@ export default function About() {
           
           <div className="space-y-3 md:space-y-4 text-sm md:text-base">
             <p>
-              In this era, simply being useful isn't enough. AI can easily build tools, but it can't create community.
+              In this era, simply being useful isn’t enough. AI can easily build tools, but it can’t create community.
             </p>
             
             <p>
@@ -114,7 +114,7 @@ export default function About() {
             </p>
             
             <p>
-              The next wave of great software isn't just about what you can build—it's about why it matters to your users. Building that kind of meaningful connection is what will truly set your product apart.
+              The next wave of great software isn’t just about what you can build—it’s about why it matters to your users. Building that kind of meaningful connection is what will truly set your product apart.
             </p>
           </div>
         </div>
@@ -127,15 +127,15 @@ export default function About() {
           
           <div className="space-y-3 md:space-y-4 text-sm md:text-base">
             <p>
-              If you're a new founder with fresh ideas, or an established brand ready to evolve, understanding this shift is key.
+              If you’re a new founder with fresh ideas, or an established brand ready to evolve, understanding this shift is key.
             </p>
             
             <p>
-              At Wild Studios, we don't just prepare for what's next—we help you build it.
+              At Wild Studios, we don’t just prepare for what’s next—we help you build it.
             </p>
             
             <p>
-              Let's make something meaningful together.
+              Let’s make something meaningful together.
             </p>
             
             <p className="italic">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -115,13 +115,13 @@ export default function Home() {
             <div className="relative">
               <div className="absolute -left-4 md:-left-8 top-0 text-4xl md:text-5xl font-bold text-gray-100 select-none">01</div>
               <h2 className="text-xl md:text-2xl font-bold mb-3 md:mb-4 relative">
-                Where We're At
+                Where We’re At
               </h2>
               <div className="space-y-3 md:space-y-4 text-sm md:text-base text-gray-700">
                 <p>At Wild Studios, we help brands and creators build meaningful tools and experiences.</p>
                 <p>AI is dramatically lowering the barrier to building software. This trend will only accelerate, fundamentally changing how we design and create software-based experiences.</p>
                 <p>Yet building genuinely valuable software—and a sustainable software business—remains complex, time-consuming, and fragile. Hiring good talent feels impossible, even as talented people struggle to find meaningful roles. Wild Studios acknowledges these contradictions without simplifying or avoiding them.</p>
-                <p>We leverage AI's strengths—rapid prototyping, generative media, and agentic workflows—while staying grounded in the practical realities and challenges of building software that genuinely works.</p>
+                <p>We leverage AI’s strengths—rapid prototyping, generative media, and agentic workflows—while staying grounded in the practical realities and challenges of building software that genuinely works.</p>
               </div>
             </div>
 
@@ -131,7 +131,7 @@ export default function Home() {
                 Tools Are Easy, Real Products Are Hard
               </h2>
               <div className="space-y-3 md:space-y-4 text-sm md:text-base text-gray-700">
-                <p>The next wave of successful software won't rely solely on new tools. Instead, it will blend AI-powered front-end and backend capabilities: AI agents enhancing traditional interfaces, frontend agents interacting seamlessly with backend systems, or entirely headless workflows delivering uniquely generative outcomes.</p>
+                <p>The next wave of successful software won’t rely solely on new tools. Instead, it will blend AI-powered front-end and backend capabilities: AI agents enhancing traditional interfaces, frontend agents interacting seamlessly with backend systems, or entirely headless workflows delivering uniquely generative outcomes.</p>
               </div>
             </div>
 
@@ -141,9 +141,9 @@ export default function Home() {
                 Build With Wild Studios
               </h2>
               <div className="space-y-3 md:space-y-4 text-sm md:text-base text-gray-700">
-                <p>Whether you're a startup with bold new ideas or an established brand ready to evolve, the real opportunity lies in balancing innovation with practical execution.</p>
-                <p>At Wild Studios, we don't just anticipate what's next—we help you build it.</p>
-                <p>Let's make something meaningful together.</p>
+                <p>Whether you’re a startup with bold new ideas or an established brand ready to evolve, the real opportunity lies in balancing innovation with practical execution.</p>
+                <p>At Wild Studios, we don’t just anticipate what’s next—we help you build it.</p>
+                <p>Let’s make something meaningful together.</p>
                 <p className="italic">— The team at Wild Studios</p>
               </div>
             </div>

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -55,7 +55,7 @@ export default async function ProjectPage({ params }: ProjectPageProps) {
               <section>
                 <h2 className="text-2xl font-bold mb-4">Overview</h2>
                 <p className="text-gray-700">
-                  {project.overview || `Working with ${project.name} was an extraordinary opportunity to push the boundaries of what's possible. 
+                  {project.overview || `Working with ${project.name} was an extraordinary opportunity to push the boundaries of what’s possible.
                   Our collaboration focused on creating meaningful digital experiences that resonate with users while 
                   driving business growth.`}
                 </p>
@@ -74,7 +74,7 @@ export default async function ProjectPage({ params }: ProjectPageProps) {
                 <h2 className="text-2xl font-bold mb-4">Solution</h2>
                 <p className="text-gray-700">
                   {project.solution || `We developed a comprehensive strategy that focused on user-centered design principles, creating 
-                  seamless experiences across all touchpoints. Our team worked closely with ${project.name}'s stakeholders 
+                  seamless experiences across all touchpoints. Our team worked closely with ${project.name}’s stakeholders
                   to ensure the final product not only met but exceeded expectations.`}
                 </p>
               </section>


### PR DESCRIPTION
## Summary
- escape apostrophes on About, home, and project pages
- revert layout to use Google-hosted Inter font
- remove local `InterVariable.woff2` so the PR has no binary files

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_683fd306d3908332b1ad86a8327f74eb