### PR TITLE
Move homepage content to Work page and add flashy 3D hero

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "next": "14.1.0",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "three": "^0.177.0"
       },
       "devDependencies": {
         "@tailwindcss/aspect-ratio": "^0.4.2",
@@ -5532,6 +5533,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/three": {
+      "version": "0.177.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.177.0.tgz",
+      "integrity": "sha512-EiXv5/qWAaGI+Vz2A+JfavwYCMdGjxVsrn3oBwllUoqYeaBO75J63ZfyaQKoiLrqNHoTlUc6PFgMXnS0kI45zg==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.14",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "next": "14.1.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "three": "^0.177.0"
   },
   "devDependencies": {
     "@tailwindcss/aspect-ratio": "^0.4.2",

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -16,6 +16,7 @@ export default function Footer() {
           <div>
             <h4 className="text-xs md:text-sm text-gray-400 mb-2 md:mb-4">Info</h4>
             <ul className="space-y-1 md:space-y-2 text-sm">
+              <li><Link href="/work" className="hover:underline">Work</Link></li>
               <li><Link href="/contact" className="hover:underline">Contact</Link></li>
               <li><Link href="/about" className="hover:underline">About</Link></li>
             </ul>

--- a/src/app/components/Navigation.tsx
+++ b/src/app/components/Navigation.tsx
@@ -7,6 +7,7 @@ export default function Navigation() {
         Wild Studios
       </Link>
       <nav className="flex items-center space-x-3 md:space-x-6">
+        <Link href="/work" className="text-sm hover:underline font-medium transition-colors duration-200 hover:text-gray-700">Work</Link>
         <Link href="/about" className="text-sm hover:underline font-medium transition-colors duration-200 hover:text-gray-700">About</Link>
         <Link href="/contact" className="text-sm bg-black text-white px-3 py-1.5 md:px-4 md:py-2 hover:bg-gray-800 transition-colors duration-200">
           CONTACT US

--- a/src/app/components/ThreeScene.tsx
+++ b/src/app/components/ThreeScene.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import * as THREE from 'three';
+
+export default function ThreeScene() {
+  const mountRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const mount = mountRef.current;
+    if (!mount) return;
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(
+      75,
+      mount.clientWidth / mount.clientHeight,
+      0.1,
+      1000
+    );
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+    renderer.setSize(mount.clientWidth, mount.clientHeight);
+    mount.appendChild(renderer.domElement);
+
+    const geometry = new THREE.TorusKnotGeometry(10, 3, 100, 16);
+    const material = new THREE.MeshBasicMaterial({ color: 0x00ff99, wireframe: true });
+    const knot = new THREE.Mesh(geometry, material);
+    scene.add(knot);
+    camera.position.z = 30;
+
+    const onResize = () => {
+      renderer.setSize(mount.clientWidth, mount.clientHeight);
+      camera.aspect = mount.clientWidth / mount.clientHeight;
+      camera.updateProjectionMatrix();
+    };
+    window.addEventListener('resize', onResize);
+
+    let req: number;
+    const animate = () => {
+      knot.rotation.x += 0.01;
+      knot.rotation.y += 0.01;
+      renderer.render(scene, camera);
+      req = requestAnimationFrame(animate);
+    };
+    animate();
+
+    return () => {
+      cancelAnimationFrame(req);
+      window.removeEventListener('resize', onResize);
+      mount.removeChild(renderer.domElement);
+    };
+  }, []);
+
+  return <div ref={mountRef} className="w-full h-full" />;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,95 +1,13 @@
-import Link from 'next/link';
-import Image from 'next/image';
-import { projects } from '@/data/projects';
-import NewsletterSection from './components/NewsletterSection';
+import ThreeScene from './components/ThreeScene';
 
 export default function Home() {
   return (
-    <>
-      {/* Hero */}
-      <section className="relative flex items-center justify-center min-h-[70vh] text-center px-4 bg-gradient-to-b from-gray-900 to-black text-white">
-        <div className="space-y-6">
-          <h1 className="text-4xl md:text-6xl font-extrabold">Designing for the Imagination Era</h1>
-          <p className="max-w-2xl mx-auto text-base md:text-lg text-gray-200">
-            We craft bespoke digital experiences that blend creativity with practical engineering.
-          </p>
-          <Link
-            href="/contact"
-            className="inline-block bg-white text-black font-semibold text-sm md:text-base px-8 py-3 uppercase hover:bg-gray-200 transition"
-          >
-            Start Your Project
-          </Link>
-        </div>
-      </section>
-
-      {/* Projects */}
-      <section className="py-10 px-4">
-        <h2 className="text-sm font-medium text-center mb-6 uppercase">Selected Projects</h2>
-        <div className="max-w-4xl mx-auto grid grid-cols-2 md:grid-cols-3 gap-6 md:gap-8">
-          {projects.slice(0, 6).map((project) => (
-            <Link
-              key={project.slug}
-              href={`/projects/${project.slug}`}
-              className="group relative flex items-center justify-center border border-gray-200 bg-white p-6 hover:shadow"
-            >
-              <Image
-                src={project.logo}
-                alt={project.name}
-                width={180}
-                height={180}
-                className="w-2/3 h-2/3 object-contain transition-transform group-hover:scale-105"
-              />
-            </Link>
-          ))}
-        </div>
-      </section>
-
-      {/* What We Do */}
-      <section className="py-12 bg-gray-50 px-4">
-        <div className="max-w-5xl mx-auto grid md:grid-cols-3 gap-8 text-center">
-          <div>
-            <h3 className="text-lg font-semibold mb-2">Design &amp; Strategy</h3>
-            <p className="text-sm text-gray-700">From brand identities to prototypes, we help you visualize bold ideas.</p>
-          </div>
-          <div>
-            <h3 className="text-lg font-semibold mb-2">Automation &amp; AI</h3>
-            <p className="text-sm text-gray-700">We use automation and AI to streamline workflows and enhance products.</p>
-          </div>
-          <div>
-            <h3 className="text-lg font-semibold mb-2">Immersive Experiences</h3>
-            <p className="text-sm text-gray-700">We create AR, VR and interactive installations that captivate audiences.</p>
-          </div>
-        </div>
-      </section>
-
-      {/* About */}
-      <section className="py-12 px-4">
-        <div className="max-w-3xl mx-auto text-center space-y-4">
-          <p>Wild Studios is a creative technology studio focused on building meaningful software and experiences.</p>
-          <p>We combine design, engineering and AI to help brands transform ideas into real products.</p>
-          <Link href="/about" className="inline-block font-medium text-sm underline mt-2">
-            Learn more about us
-          </Link>
-        </div>
-      </section>
-
-      {/* CTA */}
-      <section className="py-8 text-center px-4">
-        <p className="mb-6 font-bold text-lg md:text-xl">We&apos;re currently taking on new clients.</p>
-        <Link
-          href="/contact"
-          className="inline-flex items-center bg-green-600 hover:bg-green-700 text-white py-2 px-8 font-semibold uppercase rounded-sm shadow"
-        >
-          Contact Us
-        </Link>
-      </section>
-
-      {/* Newsletter */}
-      <section className="py-12 px-4 bg-gray-50">
-        <div className="max-w-3xl mx-auto">
-          <NewsletterSection />
-        </div>
-      </section>
-    </>
+    <section className="relative h-screen overflow-hidden flex items-center justify-center bg-black text-white">
+      <ThreeScene />
+      <div className="absolute text-center px-4">
+        <h1 className="text-4xl md:text-6xl font-extrabold mb-4">Future of Coding</h1>
+        <p className="text-lg md:text-2xl">Exploring agentic software and immersive interfaces</p>
+      </div>
+    </section>
   );
 }

--- a/src/app/work/page.tsx
+++ b/src/app/work/page.tsx
@@ -1,0 +1,95 @@
+import Link from 'next/link';
+import Image from 'next/image';
+import { projects } from '@/data/projects';
+import NewsletterSection from '../components/NewsletterSection';
+
+export default function WorkPage() {
+  return (
+    <>
+      {/* Hero */}
+      <section className="relative flex items-center justify-center min-h-[70vh] text-center px-4 bg-gradient-to-b from-gray-900 to-black text-white">
+        <div className="space-y-6">
+          <h1 className="text-4xl md:text-6xl font-extrabold">Designing for the Imagination Era</h1>
+          <p className="max-w-2xl mx-auto text-base md:text-lg text-gray-200">
+            We craft bespoke digital experiences that blend creativity with practical engineering.
+          </p>
+          <Link
+            href="/contact"
+            className="inline-block bg-white text-black font-semibold text-sm md:text-base px-8 py-3 uppercase hover:bg-gray-200 transition"
+          >
+            Start Your Project
+          </Link>
+        </div>
+      </section>
+
+      {/* Projects */}
+      <section className="py-10 px-4">
+        <h2 className="text-sm font-medium text-center mb-6 uppercase">Selected Projects</h2>
+        <div className="max-w-4xl mx-auto grid grid-cols-2 md:grid-cols-3 gap-6 md:gap-8">
+          {projects.slice(0, 6).map((project) => (
+            <Link
+              key={project.slug}
+              href={`/projects/${project.slug}`}
+              className="group relative flex items-center justify-center border border-gray-200 bg-white p-6 hover:shadow"
+            >
+              <Image
+                src={project.logo}
+                alt={project.name}
+                width={180}
+                height={180}
+                className="w-2/3 h-2/3 object-contain transition-transform group-hover:scale-105"
+              />
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      {/* What We Do */}
+      <section className="py-12 bg-gray-50 px-4">
+        <div className="max-w-5xl mx-auto grid md:grid-cols-3 gap-8 text-center">
+          <div>
+            <h3 className="text-lg font-semibold mb-2">Design &amp; Strategy</h3>
+            <p className="text-sm text-gray-700">From brand identities to prototypes, we help you visualize bold ideas.</p>
+          </div>
+          <div>
+            <h3 className="text-lg font-semibold mb-2">Automation &amp; AI</h3>
+            <p className="text-sm text-gray-700">We use automation and AI to streamline workflows and enhance products.</p>
+          </div>
+          <div>
+            <h3 className="text-lg font-semibold mb-2">Immersive Experiences</h3>
+            <p className="text-sm text-gray-700">We create AR, VR and interactive installations that captivate audiences.</p>
+          </div>
+        </div>
+      </section>
+
+      {/* About */}
+      <section className="py-12 px-4">
+        <div className="max-w-3xl mx-auto text-center space-y-4">
+          <p>Wild Studios is a creative technology studio focused on building meaningful software and experiences.</p>
+          <p>We combine design, engineering and AI to help brands transform ideas into real products.</p>
+          <Link href="/about" className="inline-block font-medium text-sm underline mt-2">
+            Learn more about us
+          </Link>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-8 text-center px-4">
+        <p className="mb-6 font-bold text-lg md:text-xl">We&apos;re currently taking on new clients.</p>
+        <Link
+          href="/contact"
+          className="inline-flex items-center bg-green-600 hover:bg-green-700 text-white py-2 px-8 font-semibold uppercase rounded-sm shadow"
+        >
+          Contact Us
+        </Link>
+      </section>
+
+      {/* Newsletter */}
+      <section className="py-12 px-4 bg-gray-50">
+        <div className="max-w-3xl mx-auto">
+          <NewsletterSection />
+        </div>
+      </section>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- create new `ThreeScene` component powered by three.js
- add a new /work route and move original homepage content there
- replace homepage with a 3D hero about the future of coding
- link to the new Work page in the navigation and footer
- install three.js dependency

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_683fe1bb084083329973406f539d149f