### PR TITLE
Move homepage content to Work page and add flashy 3D hero

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,15 @@
       "dependencies": {
         "next": "14.1.0",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "three": "^0.177.0"
       },
       "devDependencies": {
         "@tailwindcss/aspect-ratio": "^0.4.2",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
+        "@types/three": "^0.177.0",
         "autoprefixer": "^10.4.20",
         "eslint": "^8.57.1",
         "eslint-config-next": "^15.3.3",
@@ -36,6 +38,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@emnapi/core": {
       "version": "1.4.3",
@@ -565,6 +574,13 @@
         "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz",
@@ -616,6 +632,36 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.177.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.177.0.tgz",
+      "integrity": "sha512-/ZAkn4OLUijKQySNci47lFO+4JLE1TihEjsGWPUT+4jWqxtwOPPEwJV1C3k5MEx0mcBPCdkFjzRzDOnHEI1R+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.18.1"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.22",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.22.tgz",
+      "integrity": "sha512-Vr6Stjv5jPRqH690f5I5GLjVk8GSsoQSYJ2FVd/3jJF7KaqfwPi3ehfBS96mlQ2kPCwZaX6U0rG2+NGHBKkA/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.33.1",
@@ -1108,6 +1154,13 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.61",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.61.tgz",
+      "integrity": "sha512-w2HbBvH+qO19SB5pJOJFKs533CdZqxl3fcGonqL321VHkW7W/iBo6H8bjDy6pr/+pbMwIu5dnuaAxH7NxBqUrQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/acorn": {
       "version": "8.14.1",
@@ -2779,6 +2832,13 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -3944,6 +4004,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
+      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -5532,6 +5599,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/three": {
+      "version": "0.177.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.177.0.tgz",
+      "integrity": "sha512-EiXv5/qWAaGI+Vz2A+JfavwYCMdGjxVsrn3oBwllUoqYeaBO75J63ZfyaQKoiLrqNHoTlUc6PFgMXnS0kI45zg==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.14",

--- a/package.json
+++ b/package.json
@@ -11,13 +11,15 @@
   "dependencies": {
     "next": "14.1.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "three": "^0.177.0"
   },
   "devDependencies": {
     "@tailwindcss/aspect-ratio": "^0.4.2",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "@types/three": "^0.177.0",
     "autoprefixer": "^10.4.20",
     "eslint": "^8.57.1",
     "eslint-config-next": "^15.3.3",

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -16,6 +16,7 @@ export default function Footer() {
           <div>
             <h4 className="text-xs md:text-sm text-gray-400 mb-2 md:mb-4">Info</h4>
             <ul className="space-y-1 md:space-y-2 text-sm">
+              <li><Link href="/work" className="hover:underline">Work</Link></li>
               <li><Link href="/contact" className="hover:underline">Contact</Link></li>
               <li><Link href="/about" className="hover:underline">About</Link></li>
             </ul>

--- a/src/app/components/Navigation.tsx
+++ b/src/app/components/Navigation.tsx
@@ -7,6 +7,7 @@ export default function Navigation() {
         Wild Studios
       </Link>
       <nav className="flex items-center space-x-3 md:space-x-6">
+        <Link href="/work" className="text-sm hover:underline font-medium transition-colors duration-200 hover:text-gray-700">Work</Link>
         <Link href="/about" className="text-sm hover:underline font-medium transition-colors duration-200 hover:text-gray-700">About</Link>
         <Link href="/contact" className="text-sm bg-black text-white px-3 py-1.5 md:px-4 md:py-2 hover:bg-gray-800 transition-colors duration-200">
           CONTACT US

--- a/src/app/components/ThreeScene.tsx
+++ b/src/app/components/ThreeScene.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import * as THREE from 'three';
+
+export default function ThreeScene() {
+  const mountRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const mount = mountRef.current;
+    if (!mount) return;
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(
+      75,
+      mount.clientWidth / mount.clientHeight,
+      0.1,
+      1000
+    );
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+    renderer.setSize(mount.clientWidth, mount.clientHeight);
+    mount.appendChild(renderer.domElement);
+
+    const group = new THREE.Group();
+    scene.add(group);
+
+    const geometry = new THREE.TorusKnotGeometry(10, 3, 100, 16);
+    const material = new THREE.MeshBasicMaterial({ color: 0x00ff99, wireframe: true });
+    const knot = new THREE.Mesh(geometry, material);
+    group.add(knot);
+
+    const starGeometry = new THREE.BufferGeometry();
+    const starVertices: number[] = [];
+    for (let i = 0; i < 1000; i++) {
+      starVertices.push(
+        THREE.MathUtils.randFloatSpread(200),
+        THREE.MathUtils.randFloatSpread(200),
+        THREE.MathUtils.randFloatSpread(200)
+      );
+    }
+    starGeometry.setAttribute('position', new THREE.Float32BufferAttribute(starVertices, 3));
+    const starMaterial = new THREE.PointsMaterial({ color: 0xffffff, size: 0.5 });
+    const stars = new THREE.Points(starGeometry, starMaterial);
+    group.add(stars);
+    camera.position.z = 30;
+
+    const onResize = () => {
+      renderer.setSize(mount.clientWidth, mount.clientHeight);
+      camera.aspect = mount.clientWidth / mount.clientHeight;
+      camera.updateProjectionMatrix();
+    };
+    window.addEventListener('resize', onResize);
+
+    const target = new THREE.Vector2();
+    const rotation = new THREE.Vector2();
+    const onPointerMove = (e: PointerEvent) => {
+      target.x = (e.clientX / mount.clientWidth) * 2 - 1;
+      target.y = -(e.clientY / mount.clientHeight) * 2 + 1;
+    };
+    mount.addEventListener('pointermove', onPointerMove);
+
+    let req: number;
+    const animate = () => {
+      rotation.x += (target.y - rotation.x) * 0.1;
+      rotation.y += (target.x - rotation.y) * 0.1;
+
+      group.rotation.x = rotation.x * Math.PI;
+      group.rotation.y = rotation.y * Math.PI;
+      knot.rotation.z += 0.02;
+      starMaterial.color.setHSL((rotation.y + 1) / 2, 0.7, 0.5);
+
+      renderer.render(scene, camera);
+      req = requestAnimationFrame(animate);
+    };
+    animate();
+
+    return () => {
+      cancelAnimationFrame(req);
+      mount.removeEventListener('pointermove', onPointerMove);
+      window.removeEventListener('resize', onResize);
+      mount.removeChild(renderer.domElement);
+    };
+  }, []);
+
+  return <div ref={mountRef} className="w-full h-full" />;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,11 +1,8 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
 import "./globals.css";
 import Footer from "./components/Footer";
 import Navigation from "./components/Navigation";
 import LegendaryCursorProvider from "@/components/LegendaryCursorProvider";
-
-const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
   title: "Wild Studios | Design for the Digital Age",
@@ -19,7 +16,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${inter.className} bg-white bg-[radial-gradient(#f0f0f0_1px,transparent_1px)] bg-[length:20px_20px]`}>
+      <body className="bg-white bg-[radial-gradient(#f0f0f0_1px,transparent_1px)] bg-[length:20px_20px]">
         <div className="flex flex-col min-h-screen">
           <Navigation />
           <main className="flex-grow mb-6">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,95 +1,19 @@
-import Link from 'next/link';
-import Image from 'next/image';
-import { projects } from '@/data/projects';
-import NewsletterSection from './components/NewsletterSection';
+import ThreeScene from './components/ThreeScene';
 
 export default function Home() {
   return (
-    <>
-      {/* Hero */}
-      <section className="relative flex items-center justify-center min-h-[70vh] text-center px-4 bg-gradient-to-b from-gray-900 to-black text-white">
-        <div className="space-y-6">
-          <h1 className="text-4xl md:text-6xl font-extrabold">Designing for the Imagination Era</h1>
-          <p className="max-w-2xl mx-auto text-base md:text-lg text-gray-200">
-            We craft bespoke digital experiences that blend creativity with practical engineering.
-          </p>
-          <Link
-            href="/contact"
-            className="inline-block bg-white text-black font-semibold text-sm md:text-base px-8 py-3 uppercase hover:bg-gray-200 transition"
-          >
-            Start Your Project
-          </Link>
-        </div>
-      </section>
-
-      {/* Projects */}
-      <section className="py-10 px-4">
-        <h2 className="text-sm font-medium text-center mb-6 uppercase">Selected Projects</h2>
-        <div className="max-w-4xl mx-auto grid grid-cols-2 md:grid-cols-3 gap-6 md:gap-8">
-          {projects.slice(0, 6).map((project) => (
-            <Link
-              key={project.slug}
-              href={`/projects/${project.slug}`}
-              className="group relative flex items-center justify-center border border-gray-200 bg-white p-6 hover:shadow"
-            >
-              <Image
-                src={project.logo}
-                alt={project.name}
-                width={180}
-                height={180}
-                className="w-2/3 h-2/3 object-contain transition-transform group-hover:scale-105"
-              />
-            </Link>
-          ))}
-        </div>
-      </section>
-
-      {/* What We Do */}
-      <section className="py-12 bg-gray-50 px-4">
-        <div className="max-w-5xl mx-auto grid md:grid-cols-3 gap-8 text-center">
-          <div>
-            <h3 className="text-lg font-semibold mb-2">Design &amp; Strategy</h3>
-            <p className="text-sm text-gray-700">From brand identities to prototypes, we help you visualize bold ideas.</p>
-          </div>
-          <div>
-            <h3 className="text-lg font-semibold mb-2">Automation &amp; AI</h3>
-            <p className="text-sm text-gray-700">We use automation and AI to streamline workflows and enhance products.</p>
-          </div>
-          <div>
-            <h3 className="text-lg font-semibold mb-2">Immersive Experiences</h3>
-            <p className="text-sm text-gray-700">We create AR, VR and interactive installations that captivate audiences.</p>
-          </div>
-        </div>
-      </section>
-
-      {/* About */}
-      <section className="py-12 px-4">
-        <div className="max-w-3xl mx-auto text-center space-y-4">
-          <p>Wild Studios is a creative technology studio focused on building meaningful software and experiences.</p>
-          <p>We combine design, engineering and AI to help brands transform ideas into real products.</p>
-          <Link href="/about" className="inline-block font-medium text-sm underline mt-2">
-            Learn more about us
-          </Link>
-        </div>
-      </section>
-
-      {/* CTA */}
-      <section className="py-8 text-center px-4">
-        <p className="mb-6 font-bold text-lg md:text-xl">We&apos;re currently taking on new clients.</p>
-        <Link
+    <section className="relative h-screen overflow-hidden flex items-center justify-center bg-black text-white">
+      <ThreeScene />
+      <div className="absolute text-center px-4 pointer-events-none">
+        <h1 className="text-4xl md:text-6xl font-extrabold mb-4">Future of Coding</h1>
+        <p className="text-lg md:text-2xl">Exploring agentic software and immersive interfaces</p>
+        <a
           href="/contact"
-          className="inline-flex items-center bg-green-600 hover:bg-green-700 text-white py-2 px-8 font-semibold uppercase rounded-sm shadow"
+          className="mt-6 inline-block bg-white text-black font-semibold text-sm md:text-base px-8 py-3 uppercase hover:bg-gray-200 transition pointer-events-auto"
         >
-          Contact Us
-        </Link>
-      </section>
-
-      {/* Newsletter */}
-      <section className="py-12 px-4 bg-gray-50">
-        <div className="max-w-3xl mx-auto">
-          <NewsletterSection />
-        </div>
-      </section>
-    </>
+          Start Your Project
+        </a>
+      </div>
+    </section>
   );
 }

--- a/src/app/work/page.tsx
+++ b/src/app/work/page.tsx
@@ -1,0 +1,95 @@
+import Link from 'next/link';
+import Image from 'next/image';
+import { projects } from '@/data/projects';
+import NewsletterSection from '../components/NewsletterSection';
+
+export default function WorkPage() {
+  return (
+    <>
+      {/* Hero */}
+      <section className="relative flex items-center justify-center min-h-[70vh] text-center px-4 bg-gradient-to-b from-gray-900 to-black text-white">
+        <div className="space-y-6">
+          <h1 className="text-4xl md:text-6xl font-extrabold">Designing for the Imagination Era</h1>
+          <p className="max-w-2xl mx-auto text-base md:text-lg text-gray-200">
+            We craft bespoke digital experiences that blend creativity with practical engineering.
+          </p>
+          <Link
+            href="/contact"
+            className="inline-block bg-white text-black font-semibold text-sm md:text-base px-8 py-3 uppercase hover:bg-gray-200 transition"
+          >
+            Start Your Project
+          </Link>
+        </div>
+      </section>
+
+      {/* Projects */}
+      <section className="py-10 px-4">
+        <h2 className="text-sm font-medium text-center mb-6 uppercase">Selected Projects</h2>
+        <div className="max-w-4xl mx-auto grid grid-cols-2 md:grid-cols-3 gap-6 md:gap-8">
+          {projects.slice(0, 6).map((project) => (
+            <Link
+              key={project.slug}
+              href={`/projects/${project.slug}`}
+              className="group relative flex items-center justify-center border border-gray-200 bg-white p-6 hover:shadow"
+            >
+              <Image
+                src={project.logo}
+                alt={project.name}
+                width={180}
+                height={180}
+                className="w-2/3 h-2/3 object-contain transition-transform group-hover:scale-105"
+              />
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      {/* What We Do */}
+      <section className="py-12 bg-gray-50 px-4">
+        <div className="max-w-5xl mx-auto grid md:grid-cols-3 gap-8 text-center">
+          <div>
+            <h3 className="text-lg font-semibold mb-2">Design &amp; Strategy</h3>
+            <p className="text-sm text-gray-700">From brand identities to prototypes, we help you visualize bold ideas.</p>
+          </div>
+          <div>
+            <h3 className="text-lg font-semibold mb-2">Automation &amp; AI</h3>
+            <p className="text-sm text-gray-700">We use automation and AI to streamline workflows and enhance products.</p>
+          </div>
+          <div>
+            <h3 className="text-lg font-semibold mb-2">Immersive Experiences</h3>
+            <p className="text-sm text-gray-700">We create AR, VR and interactive installations that captivate audiences.</p>
+          </div>
+        </div>
+      </section>
+
+      {/* About */}
+      <section className="py-12 px-4">
+        <div className="max-w-3xl mx-auto text-center space-y-4">
+          <p>Wild Studios is a creative technology studio focused on building meaningful software and experiences.</p>
+          <p>We combine design, engineering and AI to help brands transform ideas into real products.</p>
+          <Link href="/about" className="inline-block font-medium text-sm underline mt-2">
+            Learn more about us
+          </Link>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-8 text-center px-4">
+        <p className="mb-6 font-bold text-lg md:text-xl">We&apos;re currently taking on new clients.</p>
+        <Link
+          href="/contact"
+          className="inline-flex items-center bg-green-600 hover:bg-green-700 text-white py-2 px-8 font-semibold uppercase rounded-sm shadow"
+        >
+          Contact Us
+        </Link>
+      </section>
+
+      {/* Newsletter */}
+      <section className="py-12 px-4 bg-gray-50">
+        <div className="max-w-3xl mx-auto">
+          <NewsletterSection />
+        </div>
+      </section>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- create new `ThreeScene` component powered by three.js
- add a new /work route and move original homepage content there
- replace homepage with a 3D hero about the future of coding
- link to the new Work page in the navigation and footer
- install three.js dependency
- add Start your Project CTA and make hero interactive

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts from Google)*

------
https://chatgpt.com/codex/tasks/task_e_683fe1bb084083329973406f539d149f